### PR TITLE
Translate column default value for sequences

### DIFF
--- a/ora_migrator--0.9.2.sql
+++ b/ora_migrator--0.9.2.sql
@@ -696,6 +696,7 @@ BEGIN
    END LOOP;
    s := regexp_replace(s, '\msysdate\M', 'current_date', 'gi');
    s := regexp_replace(s, '\msystimestamp\M', 'current_timestamp', 'gi');
+   s := regexp_replace(s, '"(\w[[:alnum:]$_#]*)"\."(\w[[:alnum:]$_#]*)"\."nextval"', 'nextval(''\1.\2'')', 'gi');
 
    RETURN s;
 END;$$;


### PR DESCRIPTION
This fixes
WARNING:  Error setting default value on my_column of table my_schema.my_table to ""my_schema"."my_seq"."nextval""
during db_migrate_constraints() call