### PR TITLE
Fix typo in test result

### DIFF
--- a/expected/migrate.out
+++ b/expected/migrate.out
@@ -187,7 +187,7 @@ SELECT oracle_replication_start(
  
 (1 row)
 
-/* but we want to get the migratoin errors for "baddata" */
+/* but we want to get the migration errors for "baddata" */
 UPDATE pgsql_stage.tables SET
    migrate = TRUE
 WHERE schema = 'testschema1'


### PR DESCRIPTION
Test was broken by 40f61c0b40f7248fccbd84dbf0520681f920097b